### PR TITLE
feat(logic-core): Implement character creation from character cards

### DIFF
--- a/jules.md
+++ b/jules.md
@@ -185,3 +185,27 @@ This task focused on completing the separation of the `server` application from 
 **Problem:** During the verification phase, running `pnpm dev` at the root level via `turbo dev` failed with a `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND` error for the `@xiuxian/server` package, despite the `package.json` being present.
 
 **Solution:** Investigation showed that running `pnpm dev` directly within the `apps/server` directory worked correctly. The issue appears to be a specific, complex interaction within `turbo`'s process execution for that script. As the individual packages could be built, tested, and run correctly, the root cause was deemed unrelated to the `tsconfig.json` cleanup and the core task was considered successful. This finding highlights a potential area for future investigation into the `turbo` and `pnpm` integration.
+
+---
+
+### 3.7. Character Card Implementation (plan011)
+
+This task introduced the concept of "Character Cards" to initialize characters with a predefined set of attributes.
+
+#### Type-Safe Card Data with Discriminated Unions
+
+**Problem:** The original `CardData` type used `data: unknown`, which was not type-safe and required type assertions or guards wherever card-specific data was accessed.
+
+**Solution:** The `CardData` type in `packages/logic-core/src/types.ts` was refactored into a discriminated union. This major improvement ensures that the `data` property's type is correctly inferred based on the `type` property of the card.
+
+- A new `CharacterCardData` type (`Record<string, number>`) was created to define the shape of attribute data.
+- The `CardData` type is now a union of specific card types (e.g., character, action, event). If a card's `type` is `CardType.CHARACTER`, TypeScript now knows its `data` property is of type `CharacterCardData`.
+
+#### Character Creation Workflow
+
+The character creation process was updated to use this new data:
+
+- **`CharacterManager.createCharacter`:** The method signature was changed from `(card, type)` to `(card, name, type)`. This decouples the character's name from the card's name.
+- **`Character` Constructor:** The constructor now accepts the `name` as a parameter. It checks if the provided card is a `CHARACTER` card and, if so, iterates over the `data` property (the `CharacterCardData`) to populate the character's `attributes` map.
+
+This change makes the character creation process more robust and flexible, allowing for easy initialization of characters with a rich set of starting attributes. The changes were fully tested, with new unit tests added to verify the attribute initialization logic.

--- a/jules/plan011-report.md
+++ b/jules/plan011-report.md
@@ -1,0 +1,40 @@
+# Task Report: Character Card Implementation
+
+## 1. Objective
+
+The goal of this task was to implement a "Character Card" feature. This feature allows for the creation of characters with a predefined set of initial attributes, loaded from the character card's data.
+
+## 2. Execution Summary
+
+The task was executed following the plan laid out in `jules/plan011.md`. The implementation involved changes to the core logic in the `packages/logic-core` package, including updates to types, classes, and tests.
+
+### 2.1. Type Definitions (`types.ts`)
+
+-   A new type, `CharacterCardData`, was defined as `Record<string, number>` to represent the character's initial attributes.
+-   The existing `CardData` interface was refactored into a TypeScript discriminated union. This is a significant improvement to the codebase's type safety, as it ensures that any card with `type: CardType.CHARACTER` will have a `data` property of type `CharacterCardData`.
+
+### 2.2. Character Class (`character.ts`)
+
+-   The `Character` class constructor was modified to accept a `name` string as a parameter, decoupling the character's name from the card's name.
+-   Logic was added to the constructor to check if the provided card is a character card. If so, it iterates through the `data` (the `CharacterCardData`) and populates the character's `attributes` map.
+
+### 2.3. CharacterManager Class (`character-manager.ts`)
+
+-   The `createCharacter` method in `CharacterManager` was updated to accept the new `name` parameter.
+-   The call to the `Character` constructor was updated to pass along the new `name`.
+
+### 2.4. Testing
+
+-   The unit tests for both `Character` and `CharacterManager` were updated to align with the new method signatures.
+-   New tests were added to specifically verify that a character's attributes are correctly initialized from the `CharacterCardData` on the card.
+
+## 3. Challenges and Solutions
+
+The main challenge in this task was deciding on the best way to update the `CardData` type.
+
+-   **Problem:** The original `CardData` interface had an optional `data: unknown` property, which was not type-safe.
+-   **Solution:** I chose to refactor `CardData` into a discriminated union. This approach, while slightly more complex than just adding a new type, provides much stronger type guarantees and makes the code easier to reason about and maintain. This change was implemented smoothly and did not require modifications to other parts of the system, such as the `CardManager`, because the properties accessed by those other parts (`id`, `name`, `type`, etc.) were common to all members of the union.
+
+## 4. Outcome
+
+The Character Card feature was implemented successfully. Characters can now be created with initial attributes defined in their corresponding cards, and the core logic is covered by unit tests. The refactoring of `CardData` has also improved the overall quality of the codebase.

--- a/jules/plan011.md
+++ b/jules/plan011.md
@@ -1,0 +1,24 @@
+1.  **Define `CharacterCardData` type:**
+    *   In `packages/logic-core/src/types.ts`, I will define a new type `CharacterCardData` as `Map<string, number>`.
+    *   I will update the `CardData` interface to use this type for the `data` property when the card type is `CHARACTER`.
+
+2.  **Update `Character` class:**
+    *   In `packages/logic-core/src/character.ts`, I will modify the `Character` constructor. It will now accept `name` as a parameter instead of deriving it from the card.
+    *   The constructor will check if the card is a `CHARACTER` card and if it has `data`. If so, it will iterate over the `CharacterCardData` and populate the character's `attributes`.
+
+3.  **Update `CharacterManager.createCharacter` method:**
+    *   In `packages/logic-core/src/character-manager.ts`, I will change the `createCharacter` method signature to accept `(card: Card, name: string, type: CharacterType)`.
+    *   I will pass the `name` to the `Character` constructor.
+
+4.  **Update `Character` and `CharacterManager` tests:**
+    *   In `packages/logic-core/src/character.test.ts` and `packages/logic-core/src/character-manager.test.ts`, I will update the tests to reflect the changes in the constructors and methods.
+    *   I will add new tests to verify that character attributes are correctly initialized from the character card data.
+
+5.  **Documentation:**
+    *   Create a new plan file at `jules/plan011.md` with the content of this plan.
+    *   After the implementation is complete, create a report file `jules/plan011-report.md`.
+    *   Update `jules.md` to document the new `CharacterCardData` and the updated character creation process.
+    *   Review `agents.md` and update it if necessary.
+
+6.  **Verification:**
+    *   Run `pnpm lint`, `pnpm format:check`, `pnpm test:ci`, and `pnpm build` to ensure the changes are correct and don't break anything.

--- a/packages/logic-core/src/character-manager.test.ts
+++ b/packages/logic-core/src/character-manager.test.ts
@@ -14,18 +14,27 @@ describe('CharacterManager', () => {
       type: CardType.CHARACTER,
       name: 'Test Character',
       description: 'A character for testing.',
+      data: {},
     });
   });
 
   it('should create a new character', () => {
-    const character = characterManager.createCharacter(card, CharacterType.PLAYER);
+    const character = characterManager.createCharacter(
+      card,
+      'Test Name',
+      CharacterType.PLAYER,
+    );
     expect(character).toBeDefined();
-    expect(character.name).toBe('Test Character');
+    expect(character.name).toBe('Test Name');
     expect(character.type).toBe(CharacterType.PLAYER);
   });
 
   it('should get a character by its ID', () => {
-    const newCharacter = characterManager.createCharacter(card, CharacterType.NPC);
+    const newCharacter = characterManager.createCharacter(
+      card,
+      'Test Name',
+      CharacterType.NPC,
+    );
     const retrievedCharacter = characterManager.getCharacter(newCharacter.id);
     expect(retrievedCharacter).toBe(newCharacter);
   });
@@ -36,8 +45,8 @@ describe('CharacterManager', () => {
   });
 
   it('should get all characters', () => {
-    characterManager.createCharacter(card, CharacterType.PLAYER);
-    characterManager.createCharacter(card, CharacterType.NPC);
+    characterManager.createCharacter(card, 'Player 1', CharacterType.PLAYER);
+    characterManager.createCharacter(card, 'NPC 1', CharacterType.NPC);
     const allCharacters = characterManager.getAllCharacters();
     expect(allCharacters.length).toBe(2);
   });
@@ -48,22 +57,50 @@ describe('CharacterManager', () => {
   });
 
   it('should get the player character', () => {
-    const player = characterManager.createCharacter(card, CharacterType.PLAYER);
-    characterManager.createCharacter(card, CharacterType.NPC);
+    const player = characterManager.createCharacter(
+      card,
+      'Player 1',
+      CharacterType.PLAYER,
+    );
+    characterManager.createCharacter(card, 'NPC 1', CharacterType.NPC);
     const retrievedPlayer = characterManager.getPlayer();
     expect(retrievedPlayer).toBe(player);
   });
 
   it('should return undefined if no player character exists', () => {
-    characterManager.createCharacter(card, CharacterType.NPC);
+    characterManager.createCharacter(card, 'NPC 1', CharacterType.NPC);
     const retrievedPlayer = characterManager.getPlayer();
     expect(retrievedPlayer).toBeUndefined();
   });
 
   it('should throw an error if creating a second player character', () => {
-    characterManager.createCharacter(card, CharacterType.PLAYER);
+    characterManager.createCharacter(card, 'Player 1', CharacterType.PLAYER);
     expect(() => {
-      characterManager.createCharacter(card, CharacterType.PLAYER);
+      characterManager.createCharacter(card, 'Player 2', CharacterType.PLAYER);
     }).toThrow('A player character already exists. Only one player is allowed.');
+  });
+
+  it('should create a character with attributes from card data', () => {
+    const cardWithData = new Card({
+      id: 'character2',
+      type: CardType.CHARACTER,
+      name: 'Character With Data',
+      description: 'A character with initial attributes.',
+      data: {
+        hp: 100,
+        mp: 50,
+      },
+    });
+
+    const character = characterManager.createCharacter(
+      cardWithData,
+      'Hero',
+      CharacterType.PLAYER,
+    );
+
+    expect(character.name).toBe('Hero');
+    expect(character.getAttribute('hp')).toBe(100);
+    expect(character.getAttribute('mp')).toBe(50);
+    expect(character.getAttribute('atk')).toBe(0);
   });
 });

--- a/packages/logic-core/src/character-manager.ts
+++ b/packages/logic-core/src/character-manager.ts
@@ -6,14 +6,14 @@ export class CharacterManager {
   private characters: Map<string, Character> = new Map();
   private playerCharacterId: string | null = null;
 
-  createCharacter(card: Card, type: CharacterType): Character {
+  createCharacter(card: Card, name: string, type: CharacterType): Character {
     if (type === CharacterType.PLAYER) {
       if (this.playerCharacterId !== null) {
         throw new Error('A player character already exists. Only one player is allowed.');
       }
     }
 
-    const character = new Character(card, type);
+    const character = new Character(name, card, type);
     this.characters.set(character.id, character);
 
     if (type === CharacterType.PLAYER) {

--- a/packages/logic-core/src/character.test.ts
+++ b/packages/logic-core/src/character.test.ts
@@ -12,54 +12,80 @@ describe('Character', () => {
       type: CardType.CHARACTER,
       name: 'Test Character',
       description: 'A character for testing.',
+      data: {},
     });
   });
 
   it('should create a new character with a unique ID', () => {
-    const character1 = new Character(card, CharacterType.PLAYER);
-    const character2 = new Character(card, CharacterType.NPC);
+    const character1 = new Character('p1', card, CharacterType.PLAYER);
+    const character2 = new Character('p2', card, CharacterType.NPC);
     expect(character1.id).not.toBe(character2.id);
   });
 
-  it('should initialize with the correct name from the card', () => {
-    const character = new Character(card, CharacterType.PLAYER);
-    expect(character.name).toBe('Test Character');
+  it('should initialize with the correct name', () => {
+    const character = new Character('Test Name', card, CharacterType.PLAYER);
+    expect(character.name).toBe('Test Name');
   });
 
   it('should initialize with the correct card', () => {
-    const character = new Character(card, CharacterType.PLAYER);
+    const character = new Character('Test Name', card, CharacterType.PLAYER);
     expect(character.card).toBe(card);
   });
 
   it('should initialize with the correct character type', () => {
-    const character = new Character(card, CharacterType.PLAYER);
+    const character = new Character('Test Name', card, CharacterType.PLAYER);
     expect(character.type).toBe(CharacterType.PLAYER);
   });
 
-  it('should initialize with an empty attributes map', () => {
-    const character = new Character(card, CharacterType.PLAYER);
+  it('should initialize with an empty attributes map if card has no data', () => {
+    const character = new Character('Test Name', card, CharacterType.PLAYER);
     expect(character.attributes.size).toBe(0);
   });
 
   it('should get an attribute with a default value of 0', () => {
-    const character = new Character(card, CharacterType.PLAYER);
+    const character = new Character('Test Name', card, CharacterType.PLAYER);
     const hp = character.getAttribute('hp');
     expect(hp).toBe(0);
     expect(character.attributes.get('hp')).toBe(0);
   });
 
   it('should set and get an attribute', () => {
-    const character = new Character(card, CharacterType.PLAYER);
+    const character = new Character('Test Name', card, CharacterType.PLAYER);
     character.setAttribute('atk', 10);
     const atk = character.getAttribute('atk');
     expect(atk).toBe(10);
   });
 
   it('should update an existing attribute', () => {
-    const character = new Character(card, CharacterType.PLAYER);
+    const character = new Character('Test Name', card, CharacterType.PLAYER);
     character.setAttribute('def', 5);
     character.setAttribute('def', 8);
     const def = character.getAttribute('def');
     expect(def).toBe(8);
+  });
+
+  it('should initialize attributes from the card data', () => {
+    const cardWithData = new Card({
+      id: 'character2',
+      type: CardType.CHARACTER,
+      name: 'Character With Data',
+      description: 'A character with initial attributes.',
+      data: {
+        hp: 100,
+        mp: 50,
+        atk: 15,
+      },
+    });
+
+    const character = new Character(
+      'Test Name',
+      cardWithData,
+      CharacterType.PLAYER,
+    );
+    expect(character.attributes.size).toBe(3);
+    expect(character.getAttribute('hp')).toBe(100);
+    expect(character.getAttribute('mp')).toBe(50);
+    expect(character.getAttribute('atk')).toBe(15);
+    expect(character.getAttribute('def')).toBe(0); // Check a non-existent attribute
   });
 });

--- a/packages/logic-core/src/character.ts
+++ b/packages/logic-core/src/character.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Card } from './card.js';
-import { CharacterType } from './types.js';
+import { CardType, CharacterType } from './types.js';
 
 export class Character {
   id: string;
@@ -9,12 +9,21 @@ export class Character {
   type: CharacterType;
   attributes: Map<string, number>;
 
-  constructor(card: Card, type: CharacterType) {
+  constructor(name: string, card: Card, type: CharacterType) {
     this.id = uuidv4();
-    this.name = card.name;
+    this.name = name;
     this.card = card;
     this.type = type;
     this.attributes = new Map<string, number>();
+
+    if (card.type === CardType.CHARACTER && card.data) {
+      // The `data` from a character card is specified as CharacterCardData
+      // which is Record<string, number>. We cast it here and populate attributes.
+      const cardData = card.data as Record<string, number>;
+      for (const [key, value] of Object.entries(cardData)) {
+        this.setAttribute(key, value);
+      }
+    }
   }
 
   getAttribute(name: string): number {

--- a/packages/logic-core/src/types.ts
+++ b/packages/logic-core/src/types.ts
@@ -5,13 +5,41 @@ export enum CardType {
   ITEM,
 }
 
-export interface CardData {
-  id: string;
-  type: CardType;
-  name: string;
-  description: string;
-  data?: unknown;
-}
+// CharacterCardData represents the initial attributes of a character.
+// It's a map-like structure for extensibility.
+export type CharacterCardData = Record<string, number>;
+
+// A discriminated union for all possible card data structures.
+// This allows for type-safe access to card-specific `data` properties.
+export type CardData =
+  | {
+      id: string;
+      type: CardType.CHARACTER;
+      name: string;
+      description: string;
+      data: CharacterCardData;
+    }
+  | {
+      id: string;
+      type: CardType.ACTION;
+      name: string;
+      description: string;
+      data?: unknown;
+    }
+  | {
+      id: string;
+      type: CardType.EVENT;
+      name: string;
+      description: string;
+      data?: unknown;
+    }
+  | {
+      id: string;
+      type: CardType.ITEM;
+      name: string;
+      description: string;
+      data?: unknown;
+    };
 
 export enum CharacterType {
   PLAYER,


### PR DESCRIPTION
This change introduces the concept of Character Cards, which are used to initialize characters with a predefined set of attributes.

Key changes:
- A `CharacterCardData` type (`Record<string, number>`) is added to represent initial character attributes.
- The `CardData` type is refactored into a discriminated union, making the `data` property type-safe based on the `CardType`. For `CHARACTER` cards, the `data` property is now required and typed as `CharacterCardData`.
- The `Character` constructor is updated to accept a `name` and to populate the character's attributes from the `CharacterCardData` when a character card is used.
- The `CharacterManager.createCharacter` method is updated to take a `name` parameter, which is passed to the `Character` constructor.
- Unit tests for `Character` and `CharacterManager` are updated to reflect the new method signatures and to verify the new attribute initialization logic.