### PR TITLE
feat(logic-core): add card rarity and refactor Card class

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -62,6 +62,13 @@ A strict separation between logic and view is enforced, particularly for complex
 - **Workflow:** The view (`MainScene`) captures user input, passes it to the pure logic functions, and then applies the returned values to the Pixi.js objects.
 - **Testing:** All new gameplay logic should be in a `logic` file and be covered by unit tests.
 
+### Card Data Structure
+
+The core `logic-core` package defines how cards work.
+
+- **`CardData` (`packages/logic-core/src/types.ts`):** This is the raw data definition for a card, loaded from JSON. It includes properties like `id`, `name`, `type`, and the new `rarity`. It is a discriminated union, making it type-safe.
+- **`Card` (`packages/logic-core/src/card.ts`):** This is a lightweight class that represents a card instance. It **does not** duplicate data. Instead, it holds a reference to a `CardData` object and uses getters to expose the data. When you are working with a card in the game, you will be using a `Card` object.
+
 ## Agent Instructions Verification
 
 After making changes, please verify them by running the following commands from the project root:

--- a/jules.md
+++ b/jules.md
@@ -209,3 +209,24 @@ The character creation process was updated to use this new data:
 - **`Character` Constructor:** The constructor now accepts the `name` as a parameter. It checks if the provided card is a `CHARACTER` card and, if so, iterates over the `data` property (the `CharacterCardData`) to populate the character's `attributes` map.
 
 This change makes the character creation process more robust and flexible, allowing for easy initialization of characters with a rich set of starting attributes. The changes were fully tested, with new unit tests added to verify the attribute initialization logic.
+
+---
+
+### 3.8. Card Refactoring and Rarity (plan012)
+
+This task introduced a new `rarity` system for cards and refactored the `Card` class to be more efficient and maintainable.
+
+#### Card Rarity System
+
+A new `CardRarity` enum was added to `packages/logic-core/src/types.ts`, defining four levels of rarity: `COMMON`, `RARE`, `EPIC`, and `LEGENDARY`. This enum was then integrated into the `CardData` type, making `rarity` a required attribute for all card definitions. This provides a foundation for future game mechanics based on card rarity.
+
+#### `Card` Class Refactoring
+
+**Problem:** The `Card` class was storing its own copy of all properties from its source `CardData` object (e.g., `id`, `name`, `description`). This was inefficient and meant that any future additions to `CardData` would require redundant changes in the `Card` class.
+
+**Solution:** The `Card` class was refactored to act as a lightweight wrapper around a `CardData` object.
+
+- The class now stores a single `public readonly cardData: CardData` property.
+- All other properties (`id`, `name`, `type`, `rarity`, etc.) were converted into getters that directly return the corresponding value from the `cardData` object.
+
+This change significantly improves maintainability. The `Card` class no longer duplicates data and will automatically expose any new properties added to `CardData` via new getters, without requiring further modification to its core structure. This also ensures that all `Card` instances derived from the same `CardData` are consistent. The change was implemented across the `logic-core` package, and all related unit tests were updated to reflect the new data structures, ensuring the system remains robust.

--- a/jules/plan012-report.md
+++ b/jules/plan012-report.md
@@ -1,0 +1,23 @@
+# Plan 012 Report: Refactor Card and Add Rarity
+
+## Execution Summary
+
+The goal of this task was to refactor the `Card` class to hold a reference to `CardData` and to add a `rarity` attribute to cards.
+
+The plan was executed as follows:
+
+1.  **Plan Creation**: A plan was created and saved as `jules/plan012.md`.
+2.  **`CardRarity` Enum**: The `CardRarity` enum was added to `packages/logic-core/src/types.ts`.
+3.  **`rarity` in `CardData`**: The `rarity` property was added to the `CardData` type union in `packages/logic-core/src/types.ts`.
+4.  **`Card` Class Refactor**: The `Card` class in `packages/logic-core/src/card.ts` was refactored to hold a `cardData` object and use getters to expose its properties.
+5.  **Test Updates**: The tests were updated to reflect the changes in the `CardData` type.
+
+## Problems and Solutions
+
+During the test phase, an issue was discovered. The `pnpm test` command failed during the `build` step (`tsc`).
+
+-   **Problem**: The TypeScript compiler reported errors in `packages/logic-core/src/character.test.ts` because the `CardData` objects used in the tests were missing the new `rarity` property. My initial plan had only accounted for updating `character-manager.test.ts`.
+
+-   **Solution**: I identified the missing `rarity` properties in `character.test.ts` and updated the `CardData` objects in that file to include `rarity: CardRarity.COMMON`. After this fix, all tests passed successfully.
+
+The implementation is now complete and verified.

--- a/jules/plan012.md
+++ b/jules/plan012.md
@@ -1,0 +1,23 @@
+# Plan 012: Refactor Card and Add Rarity
+
+## 1. Goal
+
+The user wants to refactor the `Card` class to hold a reference to `CardData` instead of copying all its properties. Additionally, a `rarity` concept needs to be added to `CardData`.
+
+## 2. Task Breakdown
+
+1.  **Create Plan File**: Create `jules/plan012.md` to document the plan.
+2.  **Define `CardRarity` enum**: In `packages/logic-core/src/types.ts`, create a `CardRarity` enum with the following values:
+    - `Common`
+    - `Rare`
+    - `Epic`
+    - `Legendary`
+3.  **Add `rarity` to `CardData`**: In `packages/logic-core/src/types.ts`, add a mandatory `rarity: CardRarity` field to each type within the `CardData` discriminated union.
+4.  **Refactor `Card` class**: In `packages/logic-core/src/card.ts`, modify the `Card` class to:
+    - Have a single `public readonly cardData: CardData` property in the constructor.
+    - Remove the duplicated properties (`id`, `type`, `name`, `description`, `image`, `data`).
+    - Implement getters for these properties that retrieve the values from the `cardData` object.
+5.  **Update `character-manager.test.ts`**: Modify the test to include the new `rarity` property in the `CardData` object to ensure tests pass.
+6.  **Create Report File**: After implementation, create `jules/plan012-report.md` to document the process.
+7.  **Update `jules.md`**: Update the main development documentation file with details about the changes.
+8.  **Update `agents.md`**: Review and update `agents.md` if the changes are relevant for future agent work.

--- a/packages/logic-core/src/card.ts
+++ b/packages/logic-core/src/card.ts
@@ -1,19 +1,37 @@
-import { CardType, CardData } from './types.js';
+import { CardData, CardRarity, CardType } from './types.js';
 
 export class Card {
-  id: string;
-  type: CardType;
-  name: string;
-  description: string;
-  image: string;
-  data: unknown;
+  public readonly cardData: CardData;
 
-  constructor(data: CardData) {
-    this.id = data.id;
-    this.type = data.type;
-    this.name = data.name;
-    this.description = data.description;
-    this.image = `${data.id}.png`;
-    this.data = data.data;
+  constructor(cardData: CardData) {
+    this.cardData = cardData;
+  }
+
+  get id(): string {
+    return this.cardData.id;
+  }
+
+  get type(): CardType {
+    return this.cardData.type;
+  }
+
+  get name(): string {
+    return this.cardData.name;
+  }
+
+  get description(): string {
+    return this.cardData.description;
+  }
+
+  get rarity(): CardRarity {
+    return this.cardData.rarity;
+  }
+
+  get image(): string {
+    return `${this.cardData.id}.png`;
+  }
+
+  get data(): unknown {
+    return this.cardData.data;
   }
 }

--- a/packages/logic-core/src/character-manager.test.ts
+++ b/packages/logic-core/src/character-manager.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CharacterManager } from './character-manager.js';
 import { Card } from './card.js';
-import { CardType, CharacterType } from './types.js';
+import { CardRarity, CardType, CharacterType } from './types.js';
 
 describe('CharacterManager', () => {
   let characterManager: CharacterManager;
@@ -14,6 +14,7 @@ describe('CharacterManager', () => {
       type: CardType.CHARACTER,
       name: 'Test Character',
       description: 'A character for testing.',
+      rarity: CardRarity.COMMON,
       data: {},
     });
   });
@@ -86,6 +87,7 @@ describe('CharacterManager', () => {
       type: CardType.CHARACTER,
       name: 'Character With Data',
       description: 'A character with initial attributes.',
+      rarity: CardRarity.COMMON,
       data: {
         hp: 100,
         mp: 50,

--- a/packages/logic-core/src/character.test.ts
+++ b/packages/logic-core/src/character.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Character } from './character.js';
 import { Card } from './card.js';
-import { CardType, CharacterType } from './types.js';
+import { CardRarity, CardType, CharacterType } from './types.js';
 
 describe('Character', () => {
   let card: Card;
@@ -12,6 +12,7 @@ describe('Character', () => {
       type: CardType.CHARACTER,
       name: 'Test Character',
       description: 'A character for testing.',
+      rarity: CardRarity.COMMON,
       data: {},
     });
   });
@@ -70,6 +71,7 @@ describe('Character', () => {
       type: CardType.CHARACTER,
       name: 'Character With Data',
       description: 'A character with initial attributes.',
+      rarity: CardRarity.COMMON,
       data: {
         hp: 100,
         mp: 50,

--- a/packages/logic-core/src/types.ts
+++ b/packages/logic-core/src/types.ts
@@ -1,3 +1,10 @@
+export enum CardRarity {
+  COMMON, // 白色：普通
+  RARE, // 蓝色：稀有
+  EPIC, // 紫色：史诗
+  LEGENDARY, // 橙色：传说
+}
+
 export enum CardType {
   CHARACTER,
   ACTION,
@@ -15,8 +22,9 @@ export type CardData =
   | {
       id: string;
       type: CardType.CHARACTER;
-      name: string;
+      name:string;
       description: string;
+      rarity: CardRarity;
       data: CharacterCardData;
     }
   | {
@@ -24,6 +32,7 @@ export type CardData =
       type: CardType.ACTION;
       name: string;
       description: string;
+      rarity: CardRarity;
       data?: unknown;
     }
   | {
@@ -31,6 +40,7 @@ export type CardData =
       type: CardType.EVENT;
       name: string;
       description: string;
+      rarity: CardRarity;
       data?: unknown;
     }
   | {
@@ -38,6 +48,7 @@ export type CardData =
       type: CardType.ITEM;
       name: string;
       description: string;
+      rarity: CardRarity;
       data?: unknown;
     };
 

--- a/packages/logic-core/src/types.ts
+++ b/packages/logic-core/src/types.ts
@@ -1,8 +1,8 @@
 export enum CardRarity {
-  COMMON, // 白色：普通
-  RARE, // 蓝色：稀有
-  EPIC, // 紫色：史诗
-  LEGENDARY, // 橙色：传说
+  COMMON, // White: Common
+  RARE, // Blue: Rare
+  EPIC, // Purple: Epic
+  LEGENDARY, // Orange: Legendary
 }
 
 export enum CardType {


### PR DESCRIPTION
Introduces a rarity system for cards with a new `CardRarity` enum (Common, Rare, Epic, Legendary). The `rarity` is now a required property of the `CardData` type.

Refactors the `Card` class to hold a direct reference to its `CardData` object instead of duplicating properties. All properties on the `Card` instance are now getters that retrieve data from the underlying `cardData`, improving maintainability and reducing redundancy.

Updates all relevant test files to incorporate these changes, ensuring the logic core remains fully tested and functional.